### PR TITLE
Don't set X-Frame-Options in nginx

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -117,7 +117,7 @@ nginx_sites:
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
-      add_header X-Frame-Options DENY always;
+      #add_header X-Frame-Options DENY always;
       #add_header Content-Security-Policy "default-src self" always;
 
       location '/.well-known/acme-challenge' {
@@ -141,7 +141,7 @@ nginx_sites:
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
-      add_header X-Frame-Options DENY always;
+      #add_header X-Frame-Options DENY always;
       #add_header Content-Security-Policy "default-src self" always;
       add_header Strict-Transport-Security "max-age=31536000" always;
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -117,7 +117,6 @@ nginx_sites:
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
-      #add_header X-Frame-Options DENY always;
       #add_header Content-Security-Policy "default-src self" always;
 
       location '/.well-known/acme-challenge' {
@@ -141,7 +140,6 @@ nginx_sites:
 
       add_header X-Content-Type-Options nosniff always;
       add_header X-Xss-Protection "1; mode=block" always;
-      #add_header X-Frame-Options DENY always;
       #add_header Content-Security-Policy "default-src self" always;
       add_header Strict-Transport-Security "max-age=31536000" always;
 


### PR DESCRIPTION
Addressing 107. Removing the `X-Frame-Options` header so it can be altered programmatically from within Rails. Needed for embedded shopfronts functionality.